### PR TITLE
Add i686-linux-gnu to release targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,8 @@ jobs:
             --arg filter "^${INPUT_TARGETS:-.*}$" \
             '{include: [.[] | select(.target|test($filter))]}' \
             <<<'
+              {"target": "i686-linux-gnu-shared", "runs-on": "ubuntu-latest"}
+              {"target": "i686-linux-gnu-static", "runs-on": "ubuntu-latest"}
               {"target": "x86_64-linux-gnu-shared", "runs-on": "ubuntu-latest"}
               {"target": "x86_64-linux-gnu-static", "runs-on": "ubuntu-latest"}
               {"target": "x86_64-linux-musl-shared", "runs-on": "ubuntu-latest"}

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -4,6 +4,7 @@ shopt -s inherit_errexit
 
 declare -gr NIX_PLATFORMS=(
   # Linux (GNU/glibc)
+  i686-linux-gnu
   x86_64-linux-gnu
   aarch64-linux-gnu
   # Linux (Alpine/musl)
@@ -117,6 +118,11 @@ function _build_in_docker() {
   *-linux-musl-*) docker_os=linux-musl ;;
   esac
   case "$target" in
+  i686-*)
+    # cross-compile i686 from x86_64 (CMake is no longer compiled for i686, etc.)
+    docker_platform=linux/amd64
+    docker_os+='-crossbuild-i686'
+    ;;
   x86_64-*) docker_platform=linux/amd64 ;;
   aarch64-*) docker_platform=linux/arm64 ;;
   esac
@@ -178,6 +184,7 @@ function do_build() {
     *)
       local flags
       case "$_TARGET" in
+      i686-*) flags='-m32 -march=prescott' ;;
       x86_64-*) flags='-march=westmere' ;;
       aarch64-*) flags='-march=armv8-a' ;;
       esac

--- a/tools/docker-env/linux-gnu-crossbuild-i686.Dockerfile
+++ b/tools/docker-env/linux-gnu-crossbuild-i686.Dockerfile
@@ -1,0 +1,25 @@
+FROM debian:buster
+
+# Create Debian Buster (glibc 2.28) image for cross-building i686 linux GNU binaries
+
+RUN dpkg --add-architecture i386 \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -yqq --no-install-recommends \
+        build-essential \
+        crossbuild-essential-i386 \
+        ca-certificates \
+        python3 \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN wget -O- "https://github.com/Kitware/CMake/releases/download/v3.27.8/cmake-3.27.8-linux-$(uname -m).tar.gz" \
+      | tar -xz --strip-components=1 -C /
+
+RUN groupadd -g 911 build \
+    && useradd -mN -u 911 -g 911 build
+
+COPY --chmod=700 entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+ENV CC="i686-linux-gnu-gcc" \
+    CXX="i686-linux-gnu-g++"


### PR DESCRIPTION
The lib is cross-compiled for i686 from an x86_64 docker container.

You can check the artifacts here:
https://github.com/nathan818fr/libmem/actions/runs/7134050726