### PR TITLE
Add i686-linux-musl to release targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,8 @@ jobs:
               {"target": "i686-linux-gnu-static", "runs-on": "ubuntu-latest"}
               {"target": "x86_64-linux-gnu-shared", "runs-on": "ubuntu-latest"}
               {"target": "x86_64-linux-gnu-static", "runs-on": "ubuntu-latest"}
+              {"target": "i686-linux-musl-shared", "runs-on": "ubuntu-latest"}
+              {"target": "i686-linux-musl-static", "runs-on": "ubuntu-latest"}
               {"target": "x86_64-linux-musl-shared", "runs-on": "ubuntu-latest"}
               {"target": "x86_64-linux-musl-static", "runs-on": "ubuntu-latest"}
               {"target": "i686-windows-msvc-shared-md", "runs-on": "windows-2019"}

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -8,6 +8,7 @@ declare -gr NIX_PLATFORMS=(
   x86_64-linux-gnu
   aarch64-linux-gnu
   # Linux (Alpine/musl)
+  i686-linux-musl
   x86_64-linux-musl
   aarch64-linux-musl
 )
@@ -118,11 +119,12 @@ function _build_in_docker() {
   *-linux-musl-*) docker_os=linux-musl ;;
   esac
   case "$target" in
-  i686-*)
-    # cross-compile i686 from x86_64 (CMake is no longer compiled for i686, etc.)
+  i686-linux-gnu-*)
+    # cross-compile i686 from x86_64 (CMake is no longer compiled for i686 and we can't rely on the old distro package)
     docker_platform=linux/amd64
     docker_os+='-crossbuild-i686'
     ;;
+  i686-*) docker_platform=linux/386 ;;
   x86_64-*) docker_platform=linux/amd64 ;;
   aarch64-*) docker_platform=linux/arm64 ;;
   esac


### PR DESCRIPTION
Easier than i686-linux-gnu, since we use recent alpine, with recent CMake version.
So `docker --platform=linux/386` works out of the box (and no need for qemu-user-static or similar because x86_64 hosts can run i686 docker).

I've checked the produced binaries, it's the correct architecture.