### PR TITLE
[rust] Fix for ARM architecture

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -1,11 +1,8 @@
 use std::env;
 
 fn main() {
-    let lib_path = if cfg!(windows) {
-        format!("{}{}", env::var("ProgramFiles").unwrap(), "\\libmem\\lib")
-    } else {
-        String::from("/usr/lib")
+    if cfg!(windows) {
+        let lib_path = format!("{}{}", env::var("ProgramFiles").unwrap(), "\\libmem\\lib");
+        println!("cargo:rustc-link-search={}", lib_path);
     };
-
-    println!("cargo:rustc-link-search={}", lib_path);
 }

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -25,7 +25,7 @@
 #![allow(non_snake_case)]
 
 use std::{
-    ffi::{CStr, CString},
+    ffi::{CStr, CString, c_char},
     fmt, mem, ptr,
 };
 
@@ -1100,7 +1100,7 @@ pub fn LM_DemangleSymbol(symbol: &str) -> Option<String> {
             return None;
         }
 
-        let cstr = CStr::from_ptr(newsym_raw as *const i8).to_owned();
+        let cstr = CStr::from_ptr(newsym_raw as *const c_char).to_owned();
         let newsym = string_from_cstring(cstr.as_bytes_with_nul());
 
         libmem_c::LM_FreeDemangleSymbol(newsym_raw);


### PR DESCRIPTION
- Cast cstring_t to c_char pointer instead of i8 (c_char = u8 on ARM)
- Remove explicit link search path for non-windows
  - This is very problematic when cross-compiling or compiling on a platform that doesn't use `/usr/lib` as its library dir. It should already be included by default anyways.