### PR TITLE
Allow customizing lib search path for Rust when building on Windows

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -2,7 +2,10 @@ use std::env;
 
 fn main() {
     if cfg!(windows) {
-        let lib_path = format!("{}{}", env::var("ProgramFiles").unwrap(), "\\libmem\\lib");
+        let lib_path = env::var("LIBMEM_SEARCH_PATH").unwrap_or_else(|_| {
+            format!("{}{}", env::var("ProgramFiles").unwrap(), "\\libmem\\lib")
+        });
+
         println!("cargo:rustc-link-search={}", lib_path);
     };
 }

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -2,10 +2,11 @@ use std::env;
 
 fn main() {
     if cfg!(windows) {
-        let lib_path = env::var("LIBMEM_SEARCH_PATH").unwrap_or_else(|_| {
-            format!("{}{}", env::var("ProgramFiles").unwrap(), "\\libmem\\lib")
-        });
+        if let Ok(path) = env::var("LIBMEM_SEARCH_PATH") {
+            println!("cargo:rustc-link-search={}", path);
+        }
 
+        let lib_path = format!("{}{}", env::var("ProgramFiles").unwrap(), "\\libmem\\lib");
         println!("cargo:rustc-link-search={}", lib_path);
     };
 }

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -2,7 +2,7 @@ use std::env;
 
 fn main() {
     if cfg!(windows) {
-        if let Ok(path) = env::var("LIBMEM_SEARCH_PATH") {
+        if let Ok(path) = env::var("LIBMEM_DIR") {
             println!("cargo:rustc-link-search={}", path);
         }
 


### PR DESCRIPTION
I want to place `libmem.lib` elsewhere (e.g. in my own project directory), but there's no way to configure the search path.

I added an env var `LIBMEM_SEARCH_PATH` that can be defined in the shell before building, and it will add it as an additional lib search path.

Let me know your thoughts! I can also change the var name or make other changes if you prefer.