### PR TITLE
Added LM_STATIC preprocessor flag when doing a static build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ set(LIBMEM_DEPS
 
 if (LIBMEM_BUILD_STATIC)
 	add_library(libmem STATIC ${LIBMEM_SRC})
+	target_compile_definitions(libmem PUBLIC LM_STATIC)
 else()
 	add_library(libmem SHARED ${LIBMEM_SRC})
 endif()

--- a/include/libmem/api.h
+++ b/include/libmem/api.h
@@ -40,10 +40,14 @@
 #endif
 
 /* Resolve import/export */
-#ifdef LM_EXPORT
-#	define LM_API LM_API_EXPORT
+#ifdef LM_STATIC
+#	define LM_API
 #else
-#	define LM_API LM_API_IMPORT
+#	ifdef LM_EXPORT
+#		define LM_API LM_API_EXPORT
+#	else
+#		define LM_API LM_API_IMPORT
+#	endif
 #endif
 
 /* Calling convention */


### PR DESCRIPTION
Simple PR to avoid adding "__declspec(dllexport)" to function declarations when creating a static library.