### PR TITLE
Update module.rs

### DIFF
--- a/bindings/rust/libmem/src/module.rs
+++ b/bindings/rust/libmem/src/module.rs
@@ -26,8 +26,14 @@ impl From<lm_module_t> for Module {
             base: raw_module.base,
             end: raw_module.end,
             size: raw_module.size,
-            path: unsafe { CStr::from_ptr(path_ptr).to_str().unwrap().to_owned() },
-            name: unsafe { CStr::from_ptr(name_ptr).to_str().unwrap().to_owned() },
+            path: unsafe {
+                let bytes = CStr::from_ptr(path_ptr).to_bytes();
+                String::from_utf8_lossy(bytes).to_string().to_owned()
+            },
+            name: unsafe {
+                let bytes = CStr::from_ptr(name_ptr).to_bytes();
+                String::from_utf8_lossy(bytes).to_string().to_owned()
+            },
         }
     }
 }


### PR DESCRIPTION
Repaired acquiring handle's modules.
Like once I have tried to invoke it over simple game it just printed out UTF8 error.
path: unsafe { CStr::from_ptr(path_ptr).to_str().unwrap().to_owned() },
name: unsafe { CStr::from_ptr(name_ptr).to_str().unwrap().to_owned() },
called Result::unwrap() on an Err value: Utf8Error { valid_up_to: 4, error_len: Some(1) }

So I have changed conversion to work, now it works and gain all modules names/paths properly.
```
thread 'main' panicked at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\libmem-5.0.1\src\module.rs:29:62:
called `Result::unwrap()` on an `Err` value: Utf8Error { valid_up_to: 4, error_len: Some(1) }
stack backtrace:
   0:     0x7ff734829ccd - std::backtrace_rs::backtrace::dbghelp64::trace
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278/library\std\src\..\..\backtrace\src\backtrace\dbghelp64.rs:91
   1:     0x7ff734829ccd - std::backtrace_rs::backtrace::trace_unsynchronized
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278/library\std\src\..\..\backtrace\src\backtrace\mod.rs:66
   2:     0x7ff734829ccd - std::sys::backtrace::_print_fmt
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278/library\std\src\sys\backtrace.rs:66
   3:     0x7ff734829ccd - std::sys::backtrace::impl$0::print::impl$0::fmt
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278/library\std\src\sys\backtrace.rs:39
   4:     0x7ff734849bc9 - core::fmt::rt::Argument::fmt
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278/library\core\src\fmt\rt.rs:173
   5:     0x7ff734849bc9 - core::fmt::write
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278/library\core\src\fmt\mod.rs:1178
   6:     0x7ff7348265e1 - std::io::Write::write_fmt<std::sys::pal::windows::stdio::Stderr>
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278/library\std\src\io\mod.rs:1823
   7:     0x7ff73482bdb7 - std::panicking::default_hook::closure$1
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278/library\std\src\panicking.rs:266
   8:     0x7ff73482b9a9 - std::panicking::default_hook
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278/library\std\src\panicking.rs:293
   9:     0x7ff73482c4f2 - std::panicking::rust_panic_with_hook
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278/library\std\src\panicking.rs:797
  10:     0x7ff73482c336 - std::panicking::begin_panic_handler::closure$0
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278/library\std\src\panicking.rs:671
  11:     0x7ff73482a64f - std::sys::backtrace::__rust_end_short_backtrace<std::panicking::begin_panic_handler::closure_env$0,never$>
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278/library\std\src\sys\backtrace.rs:170
  12:     0x7ff73482bf16 - std::panicking::begin_panic_handler
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278/library\std\src\panicking.rs:662
  13:     0x7ff734a55bb4 - core::panicking::panic_fmt
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278/library\core\src\panicking.rs:74
  14:     0x7ff734a560f0 - core::result::unwrap_failed
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278/library\core\src\result.rs:1679
  15:     0x7ff733f8653e - enum2$<core::result::Result<ref$<str$>,core::str::error::Utf8Error> >::unwrap
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\core\src\result.rs:1102
  16:     0x7ff733f8653e - libmem::module::impl$0::from
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\libmem-5.0.1\src\module.rs:29
  17:     0x7ff733f84f11 - core::convert::impl$3::into<libmem_sys::bindings::lm_module_t,libmem::module::Module>
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\core\src\convert\mod.rs:759
  18:     0x7ff733f87208 - libmem::module::load_module_ex
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\libmem-5.0.1\src\module.rs:168
  19:     0x7ff733eb10cf - testing::utils::processlist::inject_dll_test
                               at C:\Users\Admin\RustroverProjects\testing\src\utils\processlist.rs:55
  20:     0x7ff733eae7b3 - testing::injector_app::impl$2::update::closure$0::closure$0::closure$0::closure$4::closure$0::closure$0::closure$2
                               at C:\Users\Admin\RustroverProjects\testing\src\injector_app.rs:431
  21:     0x7ff733ed5c1e - egui_extras::layout::StripLayout::cell<testing::injector_app::impl$2::update::closure$0::closure$0::closure$0::closure$4::closure$0::closure$0::closure_env$2>
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui_extras-0.28.1\src\layout.rs:219
  22:     0x7ff733eca40f - egui_extras::layout::StripLayout::add<testing::injector_app::impl$2::update::closure$0::closure$0::closure$0::closure$4::closure$0::closure$0::closure_env$2>
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui_extras-0.28.1\src\layout.rs:149
  23:     0x7ff733e85386 - egui_extras::table::TableRow::col<testing::injector_app::impl$2::update::closure$0::closure$0::closure$0::closure$4::closure$0::closure$0::closure_env$2>
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui_extras-0.28.1\src\table.rs:1232
  24:     0x7ff733eaadfc - testing::injector_app::impl$2::update::closure$0::closure$0::closure$0::closure$4::closure$0::closure$0
                               at C:\Users\Admin\RustroverProjects\testing\src\injector_app.rs:417
  25:     0x7ff733e906ce - egui_extras::table::TableBody::row<testing::injector_app::impl$2::update::closure$0::closure$0::closure$0::closure$4::closure$0::closure_env$0>
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui_extras-0.28.1\src\table.rs:916
  26:     0x7ff733eaad05 - testing::injector_app::impl$2::update::closure$0::closure$0::closure$0::closure$4::closure$0
                               at C:\Users\Admin\RustroverProjects\testing\src\injector_app.rs:400
  27:     0x7ff733e82704 - egui_extras::table::impl$4::body::closure$0::closure$0<testing::injector_app::impl$2::update::closure$0::closure$0::closure$0::closure$4::closure_env$0>
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui_extras-0.28.1\src\table.rs:711
  28:     0x7ff733e656f8 - core::ops::function::FnOnce::call_once<egui_extras::table::impl$4::body::closure$0::closure_env$0<testing::injector_app::impl$2::update::closure$0::closure$0::closure$0::closure$4::closure_env$0>,tuple$<ref_mut$<egui::ui::Ui> > >
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\core\src\ops\function.rs:250
  29:     0x7ff73461791e - alloc::boxed::impl$48::call_once<tuple$<ref_mut$<egui::ui::Ui> >,dyn$<core::ops::function::FnOnce<tuple$<ref_mut$<egui::ui::Ui> >,assoc$<Output,tuple$<> > > >,alloc::alloc::Global>
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\alloc\src\boxed.rs:2148
  30:     0x7ff73456d00c - egui::ui::Ui::scope_dyn<tuple$<> >
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui-0.28.1\src\ui.rs:2005
  31:     0x7ff733ebe7df - egui::ui::Ui::scope<tuple$<>,egui_extras::table::impl$4::body::closure$0::closure_env$0<testing::injector_app::impl$2::update::closure$0::closure$0::closure$0::closure$4::closure_env$0> >
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui-0.28.1\src\ui.rs:1991
  32:     0x7ff733e7ff81 - egui_extras::table::impl$4::body::closure$0<testing::injector_app::impl$2::update::closure$0::closure$0::closure$0::closure$4::closure_env$0>
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui_extras-0.28.1\src\table.rs:700
  33:     0x7ff733e97b99 - egui::containers::scroll_area::impl$5::show::closure$0<tuple$<>,egui_extras::table::impl$4::body::closure_env$0<testing::injector_app::impl$2::update::closure$0::closure$0::closure$0::closure$4::closure_env$0> >
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui-0.28.1\src\containers\scroll_area.rs:691
  34:     0x7ff733e65bc2 - core::ops::function::FnOnce::call_once<egui::containers::scroll_area::impl$5::show::closure_env$0<tuple$<>,egui_extras::table::impl$4::body::closure_env$0<testing::injector_app::impl$2::update::closure$0::closure$0::closure$0::closure$4::closure_env$0> >,t
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\core\src\ops\function.rs:250
  35:     0x7ff73461822a - alloc::boxed::impl$48::call_once<tuple$<ref_mut$<egui::ui::Ui>,emath::rect::Rect>,dyn$<core::ops::function::FnOnce<tuple$<ref_mut$<egui::ui::Ui>,emath::rect::Rect>,assoc$<Output,tuple$<> > > >,alloc::alloc::Global>
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\alloc\src\boxed.rs:2148
  36:     0x7ff734554e8d - egui::containers::scroll_area::ScrollArea::show_viewport_dyn<tuple$<> >
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui-0.28.1\src\containers\scroll_area.rs:763
  37:     0x7ff733e97909 - egui::containers::scroll_area::ScrollArea::show<tuple$<>,egui_extras::table::impl$4::body::closure_env$0<testing::injector_app::impl$2::update::closure$0::closure$0::closure$0::closure$4::closure_env$0> >
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui-0.28.1\src\containers\scroll_area.rs:691
  38:     0x7ff733e7c065 - egui_extras::table::Table::body<testing::injector_app::impl$2::update::closure$0::closure$0::closure$0::closure$4::closure_env$0>
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui_extras-0.28.1\src\table.rs:695
  39:     0x7ff733e77118 - egui_extras::table::TableBuilder::body<testing::injector_app::impl$2::update::closure$0::closure$0::closure$0::closure$4::closure_env$0>
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui_extras-0.28.1\src\table.rs:503
  40:     0x7ff733eaab7f - testing::injector_app::impl$2::update::closure$0::closure$0::closure$0::closure$4
                               at C:\Users\Admin\RustroverProjects\testing\src\injector_app.rs:393
  41:     0x7ff733e657c8 - core::ops::function::FnOnce::call_once<testing::injector_app::impl$2::update::closure$0::closure$0::closure$0::closure_env$4,tuple$<ref_mut$<egui::ui::Ui> > >
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\core\src\ops\function.rs:250
  42:     0x7ff73461791e - alloc::boxed::impl$48::call_once<tuple$<ref_mut$<egui::ui::Ui> >,dyn$<core::ops::function::FnOnce<tuple$<ref_mut$<egui::ui::Ui> >,assoc$<Output,tuple$<> > > >,alloc::alloc::Global>
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\alloc\src\boxed.rs:2148
  43:     0x7ff73456bccf - egui::ui::Ui::allocate_ui_with_layout_dyn<tuple$<> >
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui-0.28.1\src\ui.rs:1136
  44:     0x7ff73456d821 - egui::ui::Ui::horizontal_with_main_wrap_dyn<tuple$<> >
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui-0.28.1\src\ui.rs:2196
  45:     0x7ff733ebce35 - egui::ui::Ui::horizontal<tuple$<>,testing::injector_app::impl$2::update::closure$0::closure$0::closure$0::closure_env$4>
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui-0.28.1\src\ui.rs:2124
  46:     0x7ff733e9c545 - testing::injector_app::impl$2::update::closure$0::closure$0::closure$0
                               at C:\Users\Admin\RustroverProjects\testing\src\injector_app.rs:392
  47:     0x7ff733e6576b - core::ops::function::FnOnce::call_once<testing::injector_app::impl$2::update::closure$0::closure$0::closure_env$0,tuple$<ref_mut$<egui::ui::Ui> > >
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\core\src\ops\function.rs:250
  48:     0x7ff73461791e - alloc::boxed::impl$48::call_once<tuple$<ref_mut$<egui::ui::Ui> >,dyn$<core::ops::function::FnOnce<tuple$<ref_mut$<egui::ui::Ui> >,assoc$<Output,tuple$<> > > >,alloc::alloc::Global>
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\alloc\src\boxed.rs:2148
  49:     0x7ff73456e0ee - egui::ui::Ui::with_layout_dyn<tuple$<> >
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui-0.28.1\src\ui.rs:2286
  50:     0x7ff733ebf03e - egui::ui::Ui::vertical<tuple$<>,testing::injector_app::impl$2::update::closure$0::closure$0::closure_env$0>
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui-0.28.1\src\ui.rs:2214
  51:     0x7ff733e9bc48 - testing::injector_app::impl$2::update::closure$0::closure$0
                               at C:\Users\Admin\RustroverProjects\testing\src\injector_app.rs:160
  52:     0x7ff733e65c1b - core::ops::function::FnOnce::call_once<testing::injector_app::impl$2::update::closure$0::closure_env$0,tuple$<ref_mut$<egui::ui::Ui> > >
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\core\src\ops\function.rs:250
  53:     0x7ff73461791e - alloc::boxed::impl$48::call_once<tuple$<ref_mut$<egui::ui::Ui> >,dyn$<core::ops::function::FnOnce<tuple$<ref_mut$<egui::ui::Ui> >,assoc$<Output,tuple$<> > > >,alloc::alloc::Global>
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\alloc\src\boxed.rs:2148
  54:     0x7ff73456bccf - egui::ui::Ui::allocate_ui_with_layout_dyn<tuple$<> >
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui-0.28.1\src\ui.rs:1136
  55:     0x7ff73456d821 - egui::ui::Ui::horizontal_with_main_wrap_dyn<tuple$<> >
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui-0.28.1\src\ui.rs:2196
  56:     0x7ff733ebcf88 - egui::ui::Ui::horizontal<tuple$<>,testing::injector_app::impl$2::update::closure$0::closure_env$0>
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui-0.28.1\src\ui.rs:2124
  57:     0x7ff733e9bc03 - testing::injector_app::impl$2::update::closure$0
                               at C:\Users\Admin\RustroverProjects\testing\src\injector_app.rs:159
  58:     0x7ff733e65c4b - core::ops::function::FnOnce::call_once<testing::injector_app::impl$2::update::closure_env$0,tuple$<ref_mut$<egui::ui::Ui> > >
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\core\src\ops\function.rs:250
  59:     0x7ff73461791e - alloc::boxed::impl$48::call_once<tuple$<ref_mut$<egui::ui::Ui> >,dyn$<core::ops::function::FnOnce<tuple$<ref_mut$<egui::ui::Ui> >,assoc$<Output,tuple$<> > > >,alloc::alloc::Global>
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\alloc\src\boxed.rs:2148
  60:     0x7ff733eb9a00 - egui::containers::panel::impl$8::show_inside_dyn::closure$1<tuple$<> >
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui-0.28.1\src\containers\panel.rs:1104
  61:     0x7ff733e65a02 - core::ops::function::FnOnce::call_once<egui::containers::panel::impl$8::show_inside_dyn::closure_env$1<tuple$<> >,tuple$<ref_mut$<egui::ui::Ui> > >
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\core\src\ops\function.rs:250
  62:     0x7ff73461791e - alloc::boxed::impl$48::call_once<tuple$<ref_mut$<egui::ui::Ui> >,dyn$<core::ops::function::FnOnce<tuple$<ref_mut$<egui::ui::Ui> >,assoc$<Output,tuple$<> > > >,alloc::alloc::Global>
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\alloc\src\boxed.rs:2148
  63:     0x7ff7345955a0 - egui::containers::frame::Frame::show_dyn<tuple$<> >
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui-0.28.1\src\containers\frame.rs:280
  64:     0x7ff733e9508f - egui::containers::frame::Frame::show<tuple$<>,egui::containers::panel::impl$8::show_inside_dyn::closure_env$1<tuple$<> > >
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui-0.28.1\src\containers\frame.rs:270
  65:     0x7ff733eb9924 - egui::containers::panel::CentralPanel::show_inside_dyn<tuple$<> >
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui-0.28.1\src\containers\panel.rs:1102
  66:     0x7ff733eb9cce - egui::containers::panel::CentralPanel::show_dyn<tuple$<> >
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui-0.28.1\src\containers\panel.rs:1137
  67:     0x7ff733eb9af3 - egui::containers::panel::CentralPanel::show<tuple$<>,testing::injector_app::impl$2::update::closure_env$0>
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui-0.28.1\src\containers\panel.rs:1114
  68:     0x7ff733ebb002 - testing::injector_app::impl$2::update
                               at C:\Users\Admin\RustroverProjects\testing\src\injector_app.rs:158
  69:     0x7ff7342aa14c - eframe::native::epi_integration::impl$0::update::closure$0
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\eframe-0.28.1\src\native\epi_integration.rs:317
  70:     0x7ff734285011 - egui::context::Context::run<eframe::native::epi_integration::impl$0::update::closure_env$0>
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\egui-0.28.1\src\context.rs:753
  71:     0x7ff7342a9d74 - eframe::native::epi_integration::EpiIntegration::update
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\eframe-0.28.1\src\native\epi_integration.rs:310
  72:     0x7ff7342c0980 - eframe::native::glow_integration::GlowWinitRunning::run_ui_and_paint
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\eframe-0.28.1\src\native\glow_integration.rs:614
  73:     0x7ff7342bf115 - eframe::native::glow_integration::impl$1::run_ui_and_paint
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\eframe-0.28.1\src\native\glow_integration.rs:403
  74:     0x7ff7342ab3bc - eframe::native::run::run_and_return::closure$0<eframe::native::glow_integration::GlowWinitApp>
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\eframe-0.28.1\src\native\run.rs:96
  75:     0x7ff7342d2ce5 - winit::platform_impl::platform::event_loop::impl$3::run_on_demand::closure$0<enum2$<eframe::native::winit_integration::UserEvent>,eframe::native::run::run_and_return::closure_env$0<eframe::native::glow_integration::GlowWinitApp> >
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\winit-0.29.15\src\platform_impl\windows\event_loop.rs:236
  76:     0x7ff7342bb768 - alloc::boxed::impl$49::call_mut<tuple$<enum2$<winit::event::Event<enum2$<eframe::native::winit_integration::UserEvent> > > >,dyn$<core::ops::function::FnMut<tuple$<enum2$<winit::event::Event<enum2$<eframe::native::winit_integration::UserEvent> > > >,assoc$
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\alloc\src\boxed.rs:2155
  77:     0x7ff7342cf2fc - winit::platform_impl::platform::event_loop::runner::impl$3::call_event_handler::closure$0<enum2$<eframe::native::winit_integration::UserEvent> >
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\winit-0.29.15\src\platform_impl\windows\event_loop\runner.rs:250
  78:     0x7ff734288604 - core::panic::unwind_safe::impl$25::call_once<tuple$<>,winit::platform_impl::platform::event_loop::runner::impl$3::call_event_handler::closure_env$0<enum2$<eframe::native::winit_integration::UserEvent> > >
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\core\src\panic\unwind_safe.rs:272
  79:     0x7ff734278484 - std::panicking::try::do_call<core::panic::unwind_safe::AssertUnwindSafe<winit::platform_impl::platform::event_loop::runner::impl$3::call_event_handler::closure_env$0<enum2$<eframe::native::winit_integration::UserEvent> > >,tuple$<> >
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\std\src\panicking.rs:554
  80:     0x7ff73427be13 - glutin::api::egl::surface::impl$4::resize<glutin::surface::WindowSurface>
  81:     0x7ff73427816a - std::panicking::try
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\std\src\panicking.rs:518
  82:     0x7ff73427816a - std::panic::catch_unwind<core::panic::unwind_safe::AssertUnwindSafe<winit::platform_impl::platform::event_loop::runner::impl$3::call_event_handler::closure_env$0<enum2$<eframe::native::winit_integration::UserEvent> > >,tuple$<> >
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\std\src\panic.rs:345
  83:     0x7ff7342cd44f - winit::platform_impl::platform::event_loop::runner::EventLoopRunner<enum2$<eframe::native::winit_integration::UserEvent> >::catch_unwind<enum2$<eframe::native::winit_integration::UserEvent>,tuple$<>,winit::platform_impl::platform::event_loop::runner::impl$
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\winit-0.29.15\src\platform_impl\windows\event_loop\runner.rs:183
  84:     0x7ff7342cf1fb - winit::platform_impl::platform::event_loop::runner::EventLoopRunner<enum2$<eframe::native::winit_integration::UserEvent> >::call_event_handler<enum2$<eframe::native::winit_integration::UserEvent> >
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\winit-0.29.15\src\platform_impl\windows\event_loop\runner.rs:246
  85:     0x7ff7342cce23 - winit::platform_impl::platform::event_loop::runner::EventLoopRunner<enum2$<eframe::native::winit_integration::UserEvent> >::send_event<enum2$<eframe::native::winit_integration::UserEvent> >
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\winit-0.29.15\src\platform_impl\windows\event_loop\runner.rs:224
  86:     0x7ff7342d386f - winit::platform_impl::platform::event_loop::WindowData<enum2$<eframe::native::winit_integration::UserEvent> >::send_event<enum2$<eframe::native::winit_integration::UserEvent> >
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\winit-0.29.15\src\platform_impl\windows\event_loop.rs:112
  87:     0x7ff7342d5b31 - winit::platform_impl::platform::event_loop::public_window_callback_inner::closure$4<enum2$<eframe::native::winit_integration::UserEvent> >
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\winit-0.29.15\src\platform_impl\windows\event_loop.rs:1144
  88:     0x7ff73426eb67 - core::ops::function::FnOnce::call_once<winit::platform_impl::platform::event_loop::public_window_callback_inner::closure_env$4<enum2$<eframe::native::winit_integration::UserEvent> >,tuple$<> >
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\core\src\ops\function.rs:250
  89:     0x7ff7342885d1 - core::panic::unwind_safe::impl$25::call_once<tuple$<>,winit::platform_impl::platform::event_loop::public_window_callback_inner::closure_env$4<enum2$<eframe::native::winit_integration::UserEvent> > >
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\core\src\panic\unwind_safe.rs:272
  90:     0x7ff7342783a5 - std::panicking::try::do_call<core::panic::unwind_safe::AssertUnwindSafe<winit::platform_impl::platform::event_loop::public_window_callback_inner::closure_env$4<enum2$<eframe::native::winit_integration::UserEvent> > >,tuple$<> >
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\std\src\panicking.rs:554
  91:     0x7ff73427be13 - glutin::api::egl::surface::impl$4::resize<glutin::surface::WindowSurface>
  92:     0x7ff7342780b4 - std::panicking::try
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\std\src\panicking.rs:518
  93:     0x7ff7342780b4 - std::panic::catch_unwind<core::panic::unwind_safe::AssertUnwindSafe<winit::platform_impl::platform::event_loop::public_window_callback_inner::closure_env$4<enum2$<eframe::native::winit_integration::UserEvent> > >,tuple$<> >
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\std\src\panic.rs:345
  94:     0x7ff7342cd7ff - winit::platform_impl::platform::event_loop::runner::EventLoopRunner<enum2$<eframe::native::winit_integration::UserEvent> >::catch_unwind<enum2$<eframe::native::winit_integration::UserEvent>,tuple$<>,winit::platform_impl::platform::event_loop::public_window
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\winit-0.29.15\src\platform_impl\windows\event_loop\runner.rs:183
  95:     0x7ff7342d41f9 - winit::platform_impl::platform::event_loop::public_window_callback_inner<enum2$<eframe::native::winit_integration::UserEvent> >
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\winit-0.29.15\src\platform_impl\windows\event_loop.rs:2285
  96:     0x7ff7342d3b7d - winit::platform_impl::platform::event_loop::public_window_callback<enum2$<eframe::native::winit_integration::UserEvent> >
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\winit-0.29.15\src\platform_impl\windows\event_loop.rs:983
  97:     0x7ffb1ddb8271 - DispatchMessageW
  98:     0x7ffb1ddb7abb - CallWindowProcW
  99:     0x7ffabe841d74 - wglSwapBuffers
 100:     0x7ffb1ddb8271 - DispatchMessageW
 101:     0x7ffb1ddb7abb - CallWindowProcW
 102:     0x7ff73444a373 - windows::Windows::Win32::UI::WindowsAndMessaging::CallWindowProcW<windows::Windows::Win32::Foundation::HWND,windows::Windows::Win32::Foundation::WPARAM,windows::Windows::Win32::Foundation::LPARAM>
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\windows-0.48.0\src\Windows\Win32\UI\WindowsAndMessaging\mod.rs:149
 103:     0x7ff73444c224 - accesskit_windows::subclass::wnd_proc
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\accesskit_windows-0.15.1\src\subclass.rs:58
 104:     0x7ffb1ddb8271 - DispatchMessageW
 105:     0x7ffb1ddb7f2c - DispatchMessageW
 106:     0x7ffb1ddc2ded - GetClassLongW
 107:     0x7ffb1f0b2e44 - KiUserCallbackDispatcher
 108:     0x7ffb1cbf1ad4 - NtUserDispatchMessage
 109:     0x7ffb1ddb7e14 - DispatchMessageW
 110:     0x7ff7342d2f2b - winit::platform_impl::platform::event_loop::EventLoop<enum2$<eframe::native::winit_integration::UserEvent> >::dispatch_peeked_messages<enum2$<eframe::native::winit_integration::UserEvent> >
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\winit-0.29.15\src\platform_impl\windows\event_loop.rs:449
 111:     0x7ff7342d2adb - winit::platform_impl::platform::event_loop::EventLoop<enum2$<eframe::native::winit_integration::UserEvent> >::run_on_demand<enum2$<eframe::native::winit_integration::UserEvent>,eframe::native::run::run_and_return::closure_env$0<eframe::native::glow_integra
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\winit-0.29.15\src\platform_impl\windows\event_loop.rs:247
 112:     0x7ff7342af789 - winit::platform::run_on_demand::impl$0::run_on_demand<enum2$<eframe::native::winit_integration::UserEvent>,eframe::native::run::run_and_return::closure_env$0<eframe::native::glow_integration::GlowWinitApp> >
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\winit-0.29.15\src\platform\run_on_demand.rs:80
 113:     0x7ff7342aac1e - eframe::native::run::run_and_return<eframe::native::glow_integration::GlowWinitApp>
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\eframe-0.28.1\src\native\run.rs:73
 114:     0x7ff7342aeb74 - eframe::native::run::run_glow::closure$0
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\eframe-0.28.1\src\native\run.rs:399
 115:     0x7ff7342aa8e5 - eframe::native::run::with_event_loop::closure$0<enum2$<core::result::Result<tuple$<>,enum2$<eframe::Error> > >,eframe::native::run::run_glow::closure_env$0>
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\eframe-0.28.1\src\native\run.rs:58
 116:     0x7ff7342b6c14 - std::thread::local::LocalKey<core::cell::RefCell<enum2$<core::option::Option<winit::event_loop::EventLoop<enum2$<eframe::native::winit_integration::UserEvent> > > > > >::try_with<core::cell::RefCell<enum2$<core::option::Option<winit::event_loop::EventLoop<
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\std\src\thread\local.rs:283
 117:     0x7ff7342b68d3 - std::thread::local::LocalKey<core::cell::RefCell<enum2$<core::option::Option<winit::event_loop::EventLoop<enum2$<eframe::native::winit_integration::UserEvent> > > > > >::with<core::cell::RefCell<enum2$<core::option::Option<winit::event_loop::EventLoop<enum
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\std\src\thread\local.rs:260
 118:     0x7ff7342aa770 - eframe::native::run::with_event_loop<enum2$<core::result::Result<tuple$<>,enum2$<eframe::Error> > >,eframe::native::run::run_glow::closure_env$0>
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\eframe-0.28.1\src\native\run.rs:48
 119:     0x7ff7342ae78a - eframe::native::run::run_glow
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\eframe-0.28.1\src\native\run.rs:397
 120:     0x7ff73426c93c - eframe::run_native
                               at C:\Users\Admin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\eframe-0.28.1\src\lib.rs:262
 121:     0x7ff733e9a6f6 - testing::main
                               at C:\Users\Admin\RustroverProjects\testing\src\main.rs:101
 122:     0x7ff733e65e63 - core::ops::function::FnOnce::call_once<enum2$<core::result::Result<tuple$<>,enum2$<eframe::Error> > > (*)(),tuple$<> >
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\core\src\ops\function.rs:250
 123:     0x7ff733e6e4d6 - std::sys::backtrace::__rust_begin_short_backtrace<enum2$<core::result::Result<tuple$<>,enum2$<eframe::Error> > > (*)(),enum2$<core::result::Result<tuple$<>,enum2$<eframe::Error> > > >
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\std\src\sys\backtrace.rs:154
 124:     0x7ff733e7170c - std::rt::lang_start::closure$0<enum2$<core::result::Result<tuple$<>,enum2$<eframe::Error> > > >
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\std\src\rt.rs:164
 125:     0x7ff734822399 - std::rt::lang_start_internal::closure$2
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278/library\std\src\rt.rs:143
 126:     0x7ff734822399 - std::panicking::try::do_call
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278/library\std\src\panicking.rs:554
 127:     0x7ff734822399 - std::panicking::try
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278/library\std\src\panicking.rs:518
 128:     0x7ff734822399 - std::panic::catch_unwind
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278/library\std\src\panic.rs:345
 129:     0x7ff734822399 - std::rt::lang_start_internal
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278/library\std\src\rt.rs:143
 130:     0x7ff733e716da - std::rt::lang_start<enum2$<core::result::Result<tuple$<>,enum2$<eframe::Error> > > >
                               at /rustc/f8060d282d42770fadd73905e3eefb85660d3278\library\std\src\rt.rs:163
 131:     0x7ff733e9a869 - main
 132:     0x7ff734a52470 - invoke_main
                               at D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:78
 133:     0x7ff734a52470 - __scrt_common_main_seh
                               at D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
 134:     0x7ffb1dbd247d - BaseThreadInitThunk
 135:     0x7ffb1f06dfb8 - RtlUserThreadStart
error: process didn't exit successfully: `target\x86_64-pc-windows-msvc\debug\testing.exe` (exit code: 101)
```
![image](https://github.com/user-attachments/assets/52571079-9d80-436c-b417-0d22368d9ced)
After fix I have got modules and paths working.