### PR TITLE
Improve memory and process handling in Rust bindings

### DIFF
--- a/bindings/rust/libmem/src/memory.rs
+++ b/bindings/rust/libmem/src/memory.rs
@@ -153,16 +153,18 @@ pub fn alloc_memory_ex(process: &Process, size: usize, prot: Prot) -> Option<Add
 }
 
 /// Frees memory previously allocated with `alloc_memory`
-pub unsafe fn free_memory(alloc: Address, size: usize) {
-    // The return of `LM_FreeMemory` will be ignored
-    unsafe { libmem_sys::LM_FreeMemory(alloc, size) };
+pub unsafe fn free_memory(alloc: Address, size: usize) -> Option<()> {
+    let result = unsafe { libmem_sys::LM_FreeMemory(alloc, size) };
+    (result == LM_TRUE).then_some(())
 }
 
 /// Frees memory previously allocated with `alloc_memory_ex`
-pub fn free_memory_ex(process: &Process, alloc: Address, size: usize) {
+pub fn free_memory_ex(process: &Process, alloc: Address, size: usize) -> Option<()> {
     let raw_process: lm_process_t = process.to_owned().into();
-    // The return of `LM_FreeMemoryEx` will be ignored
-    unsafe { libmem_sys::LM_FreeMemoryEx(&raw_process as *const lm_process_t, alloc, size) };
+    let result = unsafe {
+        libmem_sys::LM_FreeMemoryEx(&raw_process as *const lm_process_t, alloc, size)
+    };
+    (result == LM_TRUE).then_some(())
 }
 
 /// Resolves a deep pointer based on its base address and recursing offsets

--- a/bindings/rust/libmem/tests/common.rs
+++ b/bindings/rust/libmem/tests/common.rs
@@ -1,10 +1,10 @@
-use libmem::{Process, Thread};
+use libmem::{Bits, Process, Thread};
 use libmem_sys::{LM_PID_BAD, LM_TID_BAD};
 
 pub fn check_process(process: &Process) -> bool {
     process.pid != LM_PID_BAD
         && process.ppid != LM_PID_BAD
-        && (process.bits == 64 || process.bits == 32)
+        && (process.bits == Bits::Bits64 || process.bits == Bits::Bits32)
         && process.start_time > 0
         && process.path.len() > 0
         && process.name.len() > 0

--- a/bindings/rust/libmem/tests/local.rs
+++ b/bindings/rust/libmem/tests/local.rs
@@ -12,13 +12,13 @@ fn test_get_process() {
 
 #[test]
 fn test_get_bits() {
-    assert!(get_bits() == (std::mem::size_of::<usize>() * 8));
+    assert!(<Bits as Into<usize>>::into(get_bits()) == (std::mem::size_of::<usize>() * 8));
 }
 
 #[test]
 fn test_get_system_bits() {
     let bits = get_system_bits();
-    assert!(bits == 32 || bits == 64);
+    assert!(bits == Bits::Bits32 || bits == Bits::Bits64);
 }
 
 #[test]


### PR DESCRIPTION
- Update `free_memory` and `free_memory_ex` to return `Option<()>` based on the result
- Modify process and bits checks in tests to use `Bits` enum
- Adjust bit-related tests to use new `Bits` enum comparisons