### PR TITLE
fixed LM_FindProcess() not finding processes running under Proton

### DIFF
--- a/internal/posixutils/posixutils.c
+++ b/internal/posixutils/posixutils.c
@@ -59,10 +59,17 @@ get_name_from_path(char *path, char *namebuf, size_t namesize)
 	assert(path != NULL && namebuf != NULL && namesize > 0);
 
 	last_separator = strrchr(path, '/');
-	if (last_separator == NULL)
-		name = path;
-	else
+
+    /* if forwardslash not found, check for windows path */
+	if (last_separator == NULL) {
+        last_separator = strrchr(path, '\\');
+    }
+
+    if (last_separator == NULL) {
+        name = path;
+    } else {
 		name = &last_separator[1]; /* 'name' starts at 'last path separator + 1' */
+    }
 	namelen = strlen(name);
 
 	/* Truncate name if necessary */

--- a/src/linux/utils.c
+++ b/src/linux/utils.c
@@ -123,6 +123,8 @@ get_process_path(lm_pid_t pid, lm_char_t *pathbuf, size_t pathsize)
     len = read(fd, pathbuf, pathsize -1);
     if (len == -1) {
         len = 0;
+    } else {
+        pathbuf[len] = '\0';
     }
 
     close(fd);


### PR DESCRIPTION
Using LM_FindProcess() on a proton process will always fail because /proc/pid/exe links to the wine-preloader.

This can be fixed by reading /cmdline instead of /exe. I tested it with

```cpp
LM_FindProcess("sekiro.exe", &proc); // proton, game has no arguments
LM_FindProcess("cs2", &proc); // native
LM_FindProcess("Marvel-Win64-Shipping.exe", &proc); // proton, has a bunch of arguments being passed to it
```
it can find all 3 games as expected. 